### PR TITLE
Update init.php

### DIFF
--- a/init.php
+++ b/init.php
@@ -34,7 +34,7 @@ $doctrine_cfg->set('console_commands', array_merge($doctrine_cfg->get('console_c
 );
 
 $doctrine_cfg->set('console_helpers', array_merge($doctrine_cfg->get('console_helpers', array()), array(
-    'dialog' => new \Symfony\Component\Console\Helper\DialogHelper(),
+    'dialog' => new \Symfony\Component\Console\Helper\QuestionHelper(),
                 )
         )
 );


### PR DESCRIPTION
"Symfony\Component\Console\Helper\DialogHelper" is deprecated since version 2.5 and will be removed in 3.0. Use "Symfony\Component\Console\Helper\QuestionHelper" instead.
